### PR TITLE
feat(pin to specific submodule SHA)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,17 +13,14 @@ publish = false
 crate-type = ["rlib", "staticlib"]
 
 [dependencies]
-filecoin-proofs = "0.2.0"
-logging-toolkit = "0.2.0"
-ffi-toolkit = "0.2.0"
+filecoin-proofs = { rev = "07de4ef9eac5400335229678c0cc01ab8d967273", git = "https://github.com/filecoin-project/rust-fil-proofs.git" }
+logging-toolkit = { rev = "07de4ef9eac5400335229678c0cc01ab8d967273", git = "https://github.com/filecoin-project/rust-fil-proofs.git" }
+ffi-toolkit = { rev = "c9c9d55a0810a017b0e18fddf5593e84b366daad", git = "https://github.com/filecoin-project/rust-fil-ffi-toolkit.git" }
 lazy_static = "1.3.0"
 failure = "0.1.5"
 drop_struct_macro_derive = "0.2.0"
 libc = "0.2.58"
 slog = "2.4.1"
-
-[patch.crates-io]
-filecoin-proofs = { rev = "07de4ef9eac5400335229678c0cc01ab8d967273", git = "https://github.com/filecoin-project/rust-fil-proofs.git" }
 
 [build-dependencies]
 cbindgen = "=0.8.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ libc = "0.2.58"
 slog = "2.4.1"
 
 [patch.crates-io]
-filecoin-proofs = { branch = "master", git = "https://github.com/filecoin-project/rust-fil-proofs" }
+filecoin-proofs = { rev = "07de4ef9eac5400335229678c0cc01ab8d967273", git = "https://github.com/filecoin-project/rust-fil-proofs.git" }
 
 [build-dependencies]
 cbindgen = "=0.8.4"


### PR DESCRIPTION
## Why is this PR needed?

Specifying the crate as a Git repo and branch implies nondeterministic builds, e.g. if the `master` SHA changes between build 1 and build 2, build 1 and build 2 will consume different `rust-fil-proofs` SHAs.