### PR TITLE
add release manifest

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,3 @@
+pre-release-commit-message = "chore({{crate_name}}): release {{version}}"
+pro-release-commit-message = "chore({{crate_name}}): starting development cycle for {{next_version}}"
+no-dev-version = true


### PR DESCRIPTION
## Why does this PR exist?

We'd like to disable dev versions, and we want to configure the prerelease commit messages.