### PR TITLE
feat(publish the crate)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/filecoin-project/rust-fil-proofs-ffi"
 readme = "README.md"
 edition = "2018"
-publish = false
 
 [lib]
 crate-type = ["rlib", "staticlib"]


### PR DESCRIPTION
## Why does this PR exist?

Need to publish this crate. The `sector-builder-ffi` crate depends on it.