### PR TITLE
feat(write header to OUT_DIR as per cargo docs)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,13 @@
+use std::env;
+use std::path::Path;
+
 fn main() {
     println!("cargo:rerun-if-changed=src/");
 
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let hdr_out = Path::new(&out_dir).join("include/filecoin_proofs_ffi.h");
+
     cbindgen::generate(std::env::var("CARGO_MANIFEST_DIR").unwrap())
         .expect("Could not generate header")
-        .write_to_file("include/filecoin_proofs_ffi.h");
+        .write_to_file(hdr_out);
 }


### PR DESCRIPTION
## Why does this PR exist?

The header file currently gets written to the crate root's `include` sub-directory. When releasing, this produced the following error:

```
...
   Compiling fil-sapling-crypto v0.1.0
   Compiling phase21 v0.3.0
   Compiling storage-proofs v0.3.0
   Compiling filecoin-proofs-ffi v0.4.0 (/Users/erinswenson-healey/dev/rust-fil-proofs-ffi/target/package/filecoin-proofs-ffi-0.4.0)
   Compiling filecoin-proofs v0.3.0
    Finished dev [unoptimized + debuginfo] target(s) in 2m 22s
error: failed to verify package tarball

Caused by:
  Source directory was modified by build.rs during cargo publish. Build scripts should not modify anything outside of OUT_DIR.
Added: /Users/erinswenson-healey/dev/rust-fil-proofs-ffi/target/package/filecoin-proofs-ffi-0.4.0/include/filecoin_proofs_ffi.h

To proceed despite this, pass the `--no-verify` flag.
```

To work around this, the header file should be written to `OUT_DIR`.