### PR TITLE
chore: update to latest cbindgen version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ libc = "0.2.58"
 slog = "2.4.1"
 
 [build-dependencies]
-cbindgen = "=0.8.4"
+cbindgen = "0.9"


### PR DESCRIPTION
Upgrade to that version, so that it is the same as for other FFIs
(e.g. sector-builder-ffi).

I've verified locally that the output is the same as prior to the update of cbindgen.