### PR TITLE
feat: use enum for FFI response status

### DIFF
--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -19,4 +19,5 @@ language = "C"
 prefix = "filecoin_proofs_ffi"
 
 [parse]
-parse_deps = false
+parse_deps = true
+include = ["ffi-toolkit"]

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,6 @@
 use std::slice::from_raw_parts;
 
-use ffi_toolkit::{raw_ptr, rust_str_to_c_str};
+use ffi_toolkit::{raw_ptr, rust_str_to_c_str, FCPResponseStatus};
 use filecoin_proofs as api_fns;
 use filecoin_proofs::types as api_types;
 use libc;
@@ -49,15 +49,15 @@ pub unsafe extern "C" fn verify_seal(
 
     match result {
         Ok(true) => {
-            response.status_code = 0;
+            response.status_code = FCPResponseStatus::FCPNoError;
             response.is_valid = true;
         }
         Ok(false) => {
-            response.status_code = 0;
+            response.status_code = FCPResponseStatus::FCPNoError;
             response.is_valid = false;
         }
         Err(err) => {
-            response.status_code = 1;
+            response.status_code = FCPResponseStatus::FCPUnclassifiedError;
             response.error_msg = rust_str_to_c_str(format!("{}", err));
         }
     };
@@ -110,11 +110,11 @@ pub unsafe extern "C" fn verify_post(
 
     match result {
         Ok(is_valid) => {
-            response.status_code = 0;
+            response.status_code = FCPResponseStatus::FCPNoError;
             response.is_valid = is_valid;
         }
         Err(err) => {
-            response.status_code = 1;
+            response.status_code = FCPResponseStatus::FCPUnclassifiedError;
             response.error_msg = rust_str_to_c_str(format!("{}", err));
         }
     };
@@ -166,15 +166,15 @@ pub unsafe extern "C" fn verify_piece_inclusion_proof(
 
     match result {
         Ok(true) => {
-            response.status_code = 0;
+            response.status_code = FCPResponseStatus::FCPNoError;
             response.is_valid = true;
         }
         Ok(false) => {
-            response.status_code = 0;
+            response.status_code = FCPResponseStatus::FCPNoError;
             response.is_valid = false;
         }
         Err(err) => {
-            response.status_code = 1;
+            response.status_code = FCPResponseStatus::FCPUnclassifiedError;
             response.error_msg = rust_str_to_c_str(format!("{}", err));
         }
     };
@@ -216,11 +216,11 @@ pub unsafe extern "C" fn generate_piece_commitment(
 
     match result {
         Ok(comm_p) => {
-            response.status_code = 0;
+            response.status_code = FCPResponseStatus::FCPNoError;
             response.comm_p = comm_p;
         }
         Err(err) => {
-            response.status_code = 1;
+            response.status_code = FCPResponseStatus::FCPUnclassifiedError;
             response.error_msg = rust_str_to_c_str(format!("{}", err));
         }
     }

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -1,7 +1,7 @@
 use std::ptr;
 
 use drop_struct_macro_derive::DropStructMacro;
-use ffi_toolkit::free_c_str;
+use ffi_toolkit::{free_c_str, FCPResponseStatus};
 
 ////////////////////////////////////////////////////////////////////////////////
 /// VerifySealResponse
@@ -10,7 +10,7 @@ use ffi_toolkit::free_c_str;
 #[repr(C)]
 #[derive(DropStructMacro)]
 pub struct VerifySealResponse {
-    pub status_code: isize,
+    pub status_code: FCPResponseStatus,
     pub error_msg: *const libc::c_char,
     pub is_valid: bool,
 }
@@ -18,7 +18,7 @@ pub struct VerifySealResponse {
 impl Default for VerifySealResponse {
     fn default() -> VerifySealResponse {
         VerifySealResponse {
-            status_code: 0,
+            status_code: FCPResponseStatus::FCPNoError,
             error_msg: ptr::null(),
             is_valid: false,
         }
@@ -32,7 +32,7 @@ impl Default for VerifySealResponse {
 #[repr(C)]
 #[derive(DropStructMacro)]
 pub struct VerifyPoStResponse {
-    pub status_code: isize,
+    pub status_code: FCPResponseStatus,
     pub error_msg: *const libc::c_char,
     pub is_valid: bool,
 }
@@ -40,7 +40,7 @@ pub struct VerifyPoStResponse {
 impl Default for VerifyPoStResponse {
     fn default() -> VerifyPoStResponse {
         VerifyPoStResponse {
-            status_code: 0,
+            status_code: FCPResponseStatus::FCPNoError,
             error_msg: ptr::null(),
             is_valid: false,
         }
@@ -54,7 +54,7 @@ impl Default for VerifyPoStResponse {
 #[repr(C)]
 #[derive(DropStructMacro)]
 pub struct VerifyPieceInclusionProofResponse {
-    pub status_code: isize,
+    pub status_code: FCPResponseStatus,
     pub error_msg: *const libc::c_char,
     pub is_valid: bool,
 }
@@ -62,7 +62,7 @@ pub struct VerifyPieceInclusionProofResponse {
 impl Default for VerifyPieceInclusionProofResponse {
     fn default() -> Self {
         VerifyPieceInclusionProofResponse {
-            status_code: 0,
+            status_code: FCPResponseStatus::FCPNoError,
             error_msg: ptr::null(),
             is_valid: false,
         }
@@ -76,7 +76,7 @@ impl Default for VerifyPieceInclusionProofResponse {
 #[repr(C)]
 #[derive(DropStructMacro)]
 pub struct GeneratePieceCommitmentResponse {
-    pub status_code: isize,
+    pub status_code: FCPResponseStatus,
     pub error_msg: *const libc::c_char,
     pub comm_p: [u8; 32],
 }
@@ -84,7 +84,7 @@ pub struct GeneratePieceCommitmentResponse {
 impl Default for GeneratePieceCommitmentResponse {
     fn default() -> GeneratePieceCommitmentResponse {
         GeneratePieceCommitmentResponse {
-            status_code: 0,
+            status_code: FCPResponseStatus::FCPNoError,
             error_msg: ptr::null(),
             comm_p: Default::default(),
         }


### PR DESCRIPTION
Use the central `FCPResponseStatus` enum from ffi-toolkit for the
FFI responses.

This one needs https://github.com/filecoin-project/rust-fil-ffi-toolkit/pull/2 in order to work.

Closes #8.