### PR TITLE
feat: add additional underscore to header prefix

### DIFF
--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -16,7 +16,7 @@ include_version = true
 language = "C"
 
 [export]
-prefix = "filecoin_proofs_ffi"
+prefix = "filecoin_proofs_ffi_"
 
 [parse]
 parse_deps = false


### PR DESCRIPTION
This way the names are similar to the ones from the sector builder. So it's
`filecoin_proofs_ffi_VerifyPoStResponse` instead of
`filecoin_proofs_ffiVerifyPoStResponse`.

BREAKING CHANGE: All identifiers in the header file have different names now.

I'm unsure if we want to make this change. But I if yes, would do it rather sooner than later.