### PR TITLE
add functions for pre-committing, committing, staging data, and unsealing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,3 +210,9 @@ commands:
           key: v15b-proof-params-{{ arch }}
           paths:
             - /tmp/filecoin-parameter-cache
+  install_rust:
+    steps:
+      - run:
+          name: Install Rust
+          command: |
+            curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,30 @@
-version: 2
+version: 2.1
 jobs:
+  obtain_parameters:
+    docker:
+      - image: filecoin/rust:latest
+    working_directory: /mnt/crate
+    resource_class: 2xlarge+
+    steps:
+      - configure_env
+      - install_rust
+      - run:
+          name: Install paramcache from head of rust-fil-proofs master branch
+          command: |
+            cargo install filecoin-proofs --bin=paramcache --force --git=https://github.com/filecoin-project/rust-fil-proofs.git --branch=master
+            which paramcache || { printf '%s\n' "missing paramcache binary" >&2; exit 1; }
+      - restore_parameter_cache
+      - run:
+          name: Generate Groth parameters and verifying keys
+          command: paramcache
+      - save_parameter_cache
   cargo_fetch:
     docker:
       - image: filecoin/rust:latest
     working_directory: /mnt/crate
     resource_class: xlarge
     steps:
+      - configure_env
       - checkout
       - restore_cache:
           keys:
@@ -33,6 +52,7 @@ jobs:
     working_directory: /mnt/crate
     resource_class: xlarge
     steps:
+      - configure_env
       - checkout
       - attach_workspace:
           at: "."
@@ -53,6 +73,7 @@ jobs:
     working_directory: /mnt/crate
     resource_class: xlarge
     steps:
+      - configure_env
       - checkout
       - attach_workspace:
           at: "."
@@ -69,6 +90,7 @@ jobs:
     working_directory: /mnt/crate
     resource_class: xlarge
     steps:
+      - configure_env
       - checkout
       - attach_workspace:
           at: "."
@@ -85,6 +107,7 @@ jobs:
     working_directory: /mnt/crate
     resource_class: xlarge
     steps:
+      - configure_env
       - checkout
       - attach_workspace:
           at: "."
@@ -107,6 +130,7 @@ jobs:
     working_directory: ~/crate
     resource_class: large
     steps:
+      - configure_env
       - run:
           name: Configure environment variables
           command: |
@@ -137,6 +161,7 @@ workflows:
   version: 2
   test_all:
     jobs:
+      - obtain_parameters
       - cargo_fetch
       - rustfmt:
           requires:
@@ -146,6 +171,7 @@ workflows:
             - cargo_fetch
       - test:
           requires:
+            - obtain_parameters
             - cargo_fetch
       - build_linux_release:
           requires:
@@ -159,3 +185,28 @@ workflows:
           filters:
             branches:
               only: master
+commands:
+  configure_env:
+    steps:
+      - run:
+          name: Configure environment variables
+          command: |
+            echo 'export RUST_LOG=info' >> $BASH_ENV
+            echo 'export FIL_PROOFS_PARAMETER_CACHE="/tmp/filecoin-parameter-cache"' >> $BASH_ENV
+            echo 'export RUST_BACKTRACE=FULL' >> $BASH_ENV
+            echo 'export CARGO_HOME=/tmp/cargo' >> $BASH_ENV
+            echo 'export RUSTUP_HOME=/tmp/rustup' >> $BASH_ENV
+            echo 'export PATH="${CARGO_HOME}/bin:${PATH}"' >> $BASH_ENV
+            source $BASH_ENV
+  restore_parameter_cache:
+    steps:
+      - restore_cache:
+          key: v15b-proof-params-{{ arch }}
+          paths:
+            - /tmp/filecoin-parameter-cache
+  save_parameter_cache:
+    steps:
+      - save_cache:
+          key: v15b-proof-params-{{ arch }}
+          paths:
+            - /tmp/filecoin-parameter-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
     docker:
       - image: filecoin/rust:latest
     working_directory: /mnt/crate
-    resource_class: xlarge
+    resource_class: 2xlarge+
     steps:
       - configure_env
       - checkout
@@ -64,7 +64,7 @@ jobs:
             - parameter-cache-{{ .Revision }}
       - run:
           name: Test (nightly)
-          command: cargo test --verbose --all
+          command: cargo test --release --verbose --all
           no_output_timeout: 15m
 
   rustfmt:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,9 +193,6 @@ commands:
           command: |
             echo 'export RUST_LOG=info' >> $BASH_ENV
             echo 'export FIL_PROOFS_PARAMETER_CACHE="/tmp/filecoin-parameter-cache"' >> $BASH_ENV
-            echo 'export RUST_BACKTRACE=FULL' >> $BASH_ENV
-            echo 'export CARGO_HOME=/tmp/cargo' >> $BASH_ENV
-            echo 'export RUSTUP_HOME=/tmp/rustup' >> $BASH_ENV
             echo 'export PATH="${CARGO_HOME}/bin:${PATH}"' >> $BASH_ENV
             source $BASH_ENV
   restore_parameter_cache:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,6 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,6 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-toolkit 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "filecoin-proofs 0.6.4 (git+https://github.com/filecoin-project/rust-fil-proofs.git)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,6 +686,7 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-toolkit 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "filecoin-proofs 0.6.4 (git+https://github.com/filecoin-project/rust-fil-proofs.git)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,9 +688,12 @@ dependencies = [
  "filecoin-proofs 0.6.4 (git+https://github.com/filecoin-project/rust-fil-proofs.git)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-proofs 0.6.2 (git+https://github.com/filecoin-project/rust-fil-proofs.git)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ libc = "0.2.58"
 log = "0.4.7"
 pretty_env_logger = "0.3.0"
 once_cell = "0.2.4"
-lazy_static = "1.4.0"
 
 [build-dependencies]
 cbindgen = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ libc = "0.2.58"
 log = "0.4.7"
 pretty_env_logger = "0.3.0"
 once_cell = "0.2.4"
-nodrop = "0.1.14"
 lazy_static = "1.4.0"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ log = "0.4.7"
 pretty_env_logger = "0.3.0"
 once_cell = "0.2.4"
 nodrop = "0.1.14"
+lazy_static = "1.4.0"
 
 [build-dependencies]
 cbindgen = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,11 @@ libc = "0.2.58"
 log = "0.4.7"
 pretty_env_logger = "0.3.0"
 once_cell = "0.2.4"
+nodrop = "0.1.14"
 
 [build-dependencies]
 cbindgen = "0.9"
+
+[dev-dependencies]
+rand = "0.7.2"
+tempfile = "3.0.8"

--- a/src/api.rs
+++ b/src/api.rs
@@ -22,7 +22,7 @@ use storage_proofs::hasher::pedersen::PedersenDomain;
 
 lazy_static! {
     static ref TEMPORAY_AUX_MAP: Mutex<HashMap<u64, api_types::TemporaryAux>> =
-        { Mutex::new(HashMap::new()) };
+        Mutex::new(HashMap::new());
 }
 
 /// TODO: document

--- a/src/api.rs
+++ b/src/api.rs
@@ -12,6 +12,91 @@ use storage_proofs::sector::SectorId;
 use crate::helpers;
 use crate::types::*;
 
+/// TODO: document
+///
+#[no_mangle]
+pub unsafe extern "C" fn write_with_alignment() -> *mut WriteWithAlignmentResponse {
+    catch_panic_response(|| {
+        init_log();
+
+        info!("write_with_alignment: start");
+
+        let mut response = WriteWithAlignmentResponse::default();
+
+        info!("write_with_alignment: finish");
+
+        raw_ptr(response)
+    })
+}
+
+/// TODO: document
+///
+#[no_mangle]
+pub unsafe extern "C" fn write_without_alignment() -> *mut WriteWithoutAlignmentResponse {
+    catch_panic_response(|| {
+        init_log();
+
+        info!("write_without_alignment: start");
+
+        let mut response = WriteWithoutAlignmentResponse::default();
+
+        info!("write_without_alignment: finish");
+
+        raw_ptr(response)
+    })
+}
+
+/// TODO: document
+///
+#[no_mangle]
+pub unsafe extern "C" fn seal_pre_commit() -> *mut SealPreCommitResponse {
+    catch_panic_response(|| {
+        init_log();
+
+        info!("seal_pre_commit: start");
+
+        let mut response = SealPreCommitResponse::default();
+
+        info!("seal_pre_commit: finish");
+
+        raw_ptr(response)
+    })
+}
+
+/// TODO: document
+///
+#[no_mangle]
+pub unsafe extern "C" fn seal_commit() -> *mut SealCommitResponse {
+    catch_panic_response(|| {
+        init_log();
+
+        info!("seal_commit: start");
+
+        let mut response = SealCommitResponse::default();
+
+        info!("seal_commit: finish");
+
+        raw_ptr(response)
+    })
+}
+
+/// TODO: document
+///
+#[no_mangle]
+pub unsafe extern "C" fn unseal() -> *mut UnsealResponse {
+    catch_panic_response(|| {
+        init_log();
+
+        info!("unseal: start");
+
+        let mut response = UnsealResponse::default();
+
+        info!("unseal: finish");
+
+        raw_ptr(response)
+    })
+}
+
 /// Verifies the output of seal.
 ///
 #[no_mangle]
@@ -207,6 +292,33 @@ pub unsafe extern "C" fn generate_data_commitment(
 
         raw_ptr(response)
     })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn destroy_write_alignment_response(ptr: *mut WriteWithAlignmentResponse) {
+    let _ = Box::from_raw(ptr);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn destroy_write_without_alignment_response(
+    ptr: *mut WriteWithoutAlignmentResponse,
+) {
+    let _ = Box::from_raw(ptr);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn destroy_seal_pre_commit_response(ptr: *mut SealPreCommitResponse) {
+    let _ = Box::from_raw(ptr);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn destroy_seal_commit_response(ptr: *mut SealCommitResponse) {
+    let _ = Box::from_raw(ptr);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn destroy_unseal_response(ptr: *mut UnsealResponse) {
+    let _ = Box::from_raw(ptr);
 }
 
 #[no_mangle]

--- a/src/api.rs
+++ b/src/api.rs
@@ -4,31 +4,13 @@ use ffi_toolkit::{catch_panic_response, raw_ptr, rust_str_to_c_str, FCPResponseS
 use filecoin_proofs as api_fns;
 use filecoin_proofs::{
     types as api_types, PieceInfo, PoRepConfig, PoRepProofPartitions, SectorSize,
-    UnpaddedBytesAmount,
 };
 use libc;
 use once_cell::sync::OnceCell;
 use storage_proofs::sector::SectorId;
 
 use crate::helpers;
-use crate::responses::*;
-
-#[repr(C)]
-#[derive(Clone)]
-pub struct FFIPublicPieceInfo {
-    pub num_bytes: u64,
-    pub comm_p: [u8; 32],
-}
-
-impl From<FFIPublicPieceInfo> for PieceInfo {
-    fn from(x: FFIPublicPieceInfo) -> Self {
-        let FFIPublicPieceInfo { num_bytes, comm_p } = x;
-        PieceInfo {
-            commitment: comm_p,
-            size: UnpaddedBytesAmount(num_bytes),
-        }
-    }
-}
+use crate::types::*;
 
 /// Verifies the output of seal.
 ///

--- a/src/api.rs
+++ b/src/api.rs
@@ -11,7 +11,7 @@ use filecoin_proofs::{
     SectorClass, SectorSize, UnpaddedByteIndex, UnpaddedBytesAmount,
 };
 use libc;
-use once_cell::sync::OnceCell;
+use once_cell::sync::{Lazy, OnceCell};
 use storage_proofs::hasher::Domain;
 use storage_proofs::sector::SectorId;
 
@@ -20,10 +20,8 @@ use crate::types::*;
 use std::mem;
 use storage_proofs::hasher::pedersen::PedersenDomain;
 
-lazy_static! {
-    static ref TEMPORAY_AUX_MAP: Mutex<HashMap<u64, api_types::TemporaryAux>> =
-        Mutex::new(HashMap::new());
-}
+static TEMPORAY_AUX_MAP: Lazy<Mutex<HashMap<u64, api_types::TemporaryAux>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
 
 /// TODO: document
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@
 extern crate failure;
 #[macro_use]
 extern crate log;
+#[macro_use]
+extern crate lazy_static;
 
 mod error;
 mod helpers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,4 +10,4 @@ mod error;
 mod helpers;
 
 pub mod api;
-pub mod responses;
+pub mod types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@
 extern crate failure;
 #[macro_use]
 extern crate log;
-#[macro_use]
-extern crate lazy_static;
 
 mod error;
 mod helpers;

--- a/src/types.rs
+++ b/src/types.rs
@@ -24,6 +24,96 @@ impl From<FFIPublicPieceInfo> for PieceInfo {
 
 #[repr(C)]
 #[derive(DropStructMacro)]
+pub struct WriteWithAlignmentResponse {
+    pub status_code: FCPResponseStatus,
+    pub error_msg: *const libc::c_char,
+}
+
+impl Default for WriteWithAlignmentResponse {
+    fn default() -> WriteWithAlignmentResponse {
+        WriteWithAlignmentResponse {
+            status_code: FCPResponseStatus::FCPNoError,
+            error_msg: ptr::null(),
+        }
+    }
+}
+
+code_and_message_impl!(WriteWithAlignmentResponse);
+
+#[repr(C)]
+#[derive(DropStructMacro)]
+pub struct WriteWithoutAlignmentResponse {
+    pub status_code: FCPResponseStatus,
+    pub error_msg: *const libc::c_char,
+}
+
+impl Default for WriteWithoutAlignmentResponse {
+    fn default() -> WriteWithoutAlignmentResponse {
+        WriteWithoutAlignmentResponse {
+            status_code: FCPResponseStatus::FCPNoError,
+            error_msg: ptr::null(),
+        }
+    }
+}
+
+code_and_message_impl!(WriteWithoutAlignmentResponse);
+
+#[repr(C)]
+#[derive(DropStructMacro)]
+pub struct SealPreCommitResponse {
+    pub status_code: FCPResponseStatus,
+    pub error_msg: *const libc::c_char,
+}
+
+impl Default for SealPreCommitResponse {
+    fn default() -> SealPreCommitResponse {
+        SealPreCommitResponse {
+            status_code: FCPResponseStatus::FCPNoError,
+            error_msg: ptr::null(),
+        }
+    }
+}
+
+code_and_message_impl!(SealPreCommitResponse);
+
+#[repr(C)]
+#[derive(DropStructMacro)]
+pub struct SealCommitResponse {
+    pub status_code: FCPResponseStatus,
+    pub error_msg: *const libc::c_char,
+}
+
+impl Default for SealCommitResponse {
+    fn default() -> SealCommitResponse {
+        SealCommitResponse {
+            status_code: FCPResponseStatus::FCPNoError,
+            error_msg: ptr::null(),
+        }
+    }
+}
+
+code_and_message_impl!(SealCommitResponse);
+
+#[repr(C)]
+#[derive(DropStructMacro)]
+pub struct UnsealResponse {
+    pub status_code: FCPResponseStatus,
+    pub error_msg: *const libc::c_char,
+}
+
+impl Default for UnsealResponse {
+    fn default() -> UnsealResponse {
+        UnsealResponse {
+            status_code: FCPResponseStatus::FCPNoError,
+            error_msg: ptr::null(),
+        }
+    }
+}
+
+code_and_message_impl!(UnsealResponse);
+
+#[repr(C)]
+#[derive(DropStructMacro)]
 pub struct VerifySealResponse {
     pub status_code: FCPResponseStatus,
     pub error_msg: *const libc::c_char,

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,13 +8,13 @@ use std::io::{Error, SeekFrom};
 
 /// FileDescriptorRef does not drop its file descriptor when it is dropped. Its
 /// owner must manage the lifecycle of the file descriptor.
-pub struct FileDescriptorRef(nodrop::NoDrop<std::fs::File>);
+pub struct FileDescriptorRef(std::mem::ManuallyDrop<std::fs::File>);
 
 impl FileDescriptorRef {
     #[cfg(not(target_os = "windows"))]
     pub unsafe fn new(raw: std::os::unix::io::RawFd) -> Self {
         use std::os::unix::io::FromRawFd;
-        FileDescriptorRef(nodrop::NoDrop::new(std::fs::File::from_raw_fd(raw)))
+        FileDescriptorRef(std::mem::ManuallyDrop::new(std::fs::File::from_raw_fd(raw)))
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,10 +3,24 @@ use std::ptr;
 use drop_struct_macro_derive::DropStructMacro;
 // `CodeAndMessage` is the trait implemented by `code_and_message_impl`
 use ffi_toolkit::{code_and_message_impl, free_c_str, CodeAndMessage, FCPResponseStatus};
+use filecoin_proofs::{PieceInfo, UnpaddedBytesAmount};
 
-////////////////////////////////////////////////////////////////////////////////
-/// VerifySealResponse
-//////////////////////
+#[repr(C)]
+#[derive(Clone)]
+pub struct FFIPublicPieceInfo {
+    pub num_bytes: u64,
+    pub comm_p: [u8; 32],
+}
+
+impl From<FFIPublicPieceInfo> for PieceInfo {
+    fn from(x: FFIPublicPieceInfo) -> Self {
+        let FFIPublicPieceInfo { num_bytes, comm_p } = x;
+        PieceInfo {
+            commitment: comm_p,
+            size: UnpaddedBytesAmount(num_bytes),
+        }
+    }
+}
 
 #[repr(C)]
 #[derive(DropStructMacro)]
@@ -28,10 +42,6 @@ impl Default for VerifySealResponse {
 
 code_and_message_impl!(VerifySealResponse);
 
-////////////////////////////////////////////////////////////////////////////////
-/// VerifyPoStResponse
-//////////////////////
-
 #[repr(C)]
 #[derive(DropStructMacro)]
 pub struct VerifyPoStResponse {
@@ -51,10 +61,6 @@ impl Default for VerifyPoStResponse {
 }
 
 code_and_message_impl!(VerifyPoStResponse);
-
-///////////////////////////////////////////////////////////////////////////////
-/// GeneratePieceCommitmentResponse
-///////////////////////////////////
 
 #[repr(C)]
 #[derive(DropStructMacro)]
@@ -79,10 +85,6 @@ impl Default for GeneratePieceCommitmentResponse {
 }
 
 code_and_message_impl!(GeneratePieceCommitmentResponse);
-
-///////////////////////////////////////////////////////////////////////////////
-/// GenerateDataCommitmentResponse
-//////////////////////////////////
 
 #[repr(C)]
 #[derive(DropStructMacro)]


### PR DESCRIPTION
## Why does this PR exist?

Lotus wants to seal w/out having to use a sector builder.

## What's in this PR?

This PR exposes primitive proof operations (write a piece, pre-commit, commit, unseal) to library consumers. This will allow them to build their own sector builder-like things.