### PR TITLE
deprecate project in favor of filecoin-ffi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ readme = "README.md"
 edition = "2018"
 publish = false
 
+[badges]
+maintenance = { status = "deprecated" }
+
 [lib]
 crate-type = ["rlib", "staticlib"]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Filecoin Proofs FFI
+# DEPRECATED
 
-> C bindings for filecoin-proofs.
+This repo is no longer supported. Please consider using
+[filecoin-ffi](https://github.com/filecoin-project/filecoin-ffi) instead.
 
 ## License
 


### PR DESCRIPTION
## Why does this PR exist?

We've combined proofs and bls FFI code (both CGO and C-like Rusty bindings) into a [new repo](https://github.com/filecoin-project/filecoin-ffi), which means that we can stop depending on this repo.